### PR TITLE
Improvements to Swagger integration.

### DIFF
--- a/src/main/java/pt/jmnpedrosa/samples/springboot/restful/SpringBootRestfulApplication.java
+++ b/src/main/java/pt/jmnpedrosa/samples/springboot/restful/SpringBootRestfulApplication.java
@@ -2,10 +2,8 @@ package pt.jmnpedrosa.samples.springboot.restful;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
-@EnableSwagger2
 public class SpringBootRestfulApplication {
   public static void main(String[] args) {
     SpringApplication.run(SpringBootRestfulApplication.class, args);

--- a/src/main/java/pt/jmnpedrosa/samples/springboot/restful/swagger/config/SwaggerConfig.java
+++ b/src/main/java/pt/jmnpedrosa/samples/springboot/restful/swagger/config/SwaggerConfig.java
@@ -10,6 +10,7 @@ import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 /**
  * This class configures Swagger to show all available endpoints inside our
@@ -20,6 +21,7 @@ import springfox.documentation.spring.web.plugins.Docket;
  * a flag is declared in properties to enable Swagger.
  */
 @Configuration
+@EnableSwagger2
 @ConditionalOnProperty(name = "swagger.enabled")
 public class SwaggerConfig {
 

--- a/src/main/java/pt/jmnpedrosa/samples/springboot/restful/swagger/web/DisableSwaggerUiController.java
+++ b/src/main/java/pt/jmnpedrosa/samples/springboot/restful/swagger/web/DisableSwaggerUiController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
  * a flag is declared in properties to enable it.
  */
 @RestController
-@ConditionalOnProperty(name = "swagger.enabled", havingValue = "false")
+@ConditionalOnProperty(name = "swagger.enabled", havingValue = "false", matchIfMissing = true)
 public class DisableSwaggerUiController {
 
   @GetMapping("swagger-ui.html")

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,8 +1,0 @@
-# Customize logging verbosity by package
-logging:
-  level:
-    org.springframework: INFO
-    pt.jmnpedrosa.samples.springboot.restful: DEBUG
-
-# Enable swagger in this environment
-swagger.enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,14 @@
-#B y default in Spring Boot the server port is 8080 but we can customize it here.
+# By default in Spring Boot the server port is 8080 but we can customize it here.
 server.port: 8080
+
+# Customize logging verbosity by package
+logging:
+  level:
+    org.springframework: INFO
+    pt.jmnpedrosa.samples.springboot.restful: DEBUG
+
+# Enable swagger API and UI.
+swagger.enabled: true
 
 # Read the maven version of the project in POM into a variable that is used
 # to display in Swagger UI

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,4 +1,0 @@
-# Configure the application to use the "local" profile when running locally.
-spring:
-  application.name: spring-boot-restful-sample
-  profiles.active: local


### PR DESCRIPTION
Corrections to Swagger integration with conditional enable flag in properties:

To allow **Swagger** integration with the project, the following line must be added to `application.yml` configuration file:

```yml
# Enable swagger API and UI.
swagger.enabled: true
```

With this property enabled, the Swagger JSON API becomes acessible at http://localhost:8080/v2/api-docs.
The Swagger UI will be acessible at http://localhost:8080/swagger-ui.html.

If the property is ommited or set to `false`, none of the above URIs will work, and the `404: Not Found` error will be returned.